### PR TITLE
Add RapidFuzz-based fuzzy search toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A comprehensive Streamlit web application for searching and filtering papers fro
 - **Exact phrase search**: Use quotes for exact matches
 - **Multi-field search**: Search across titles, abstracts, and authors
 - **Case-insensitive**: All searches are case-insensitive
+- **Fuzzy matching**: Optional approximate matches using RapidFuzz
 
 ### 🏷️ Filtering Options
 - **Year range**: Filter papers by publication year

--- a/api_server.py
+++ b/api_server.py
@@ -16,6 +16,8 @@ class SearchRequest(BaseModel):
     year_range: Optional[tuple[int, int]] = None
     venues: Optional[List[str]] = None
     limit: int = 100
+    fuzzy: bool = False
+    fuzzy_threshold: int = 80
 
 class SearchResponse(BaseModel):
     results: List[Dict[str, Any]]
@@ -120,7 +122,9 @@ async def search_papers(request: SearchRequest):
             query=request.query,
             fields=request.fields,
             filters=filters,
-            limit=request.limit
+            limit=request.limit,
+            fuzzy=request.fuzzy,
+            fuzzy_threshold=request.fuzzy_threshold
         )
         
         search_time = time.time() - start_time
@@ -170,7 +174,9 @@ async def search_papers_get(
     year_min: Optional[int] = Query(None, description="Minimum year"),
     year_max: Optional[int] = Query(None, description="Maximum year"),
     venues: Optional[str] = Query(None, description="Comma-separated venues"),
-    limit: int = Query(100, description="Maximum results")
+    limit: int = Query(100, description="Maximum results"),
+    fuzzy: bool = Query(False, description="Enable fuzzy matching"),
+    fuzzy_threshold: int = Query(80, description="Fuzzy matching threshold")
 ):
     """GET endpoint for search (for easy testing)"""
     
@@ -185,7 +191,9 @@ async def search_papers_get(
         fields=fields_list,
         year_range=year_range,
         venues=venues_list,
-        limit=limit
+        limit=limit,
+        fuzzy=fuzzy,
+        fuzzy_threshold=fuzzy_threshold
     )
     
     return await search_papers(request)

--- a/app.py
+++ b/app.py
@@ -219,11 +219,22 @@ def create_filters_sidebar(search_engine: BooleanSearchEngine) -> Dict[str, Any]
             help="Limit the number of search results"
         )
         st.markdown('</div>', unsafe_allow_html=True)
+
+    # Fuzzy matching toggle
+    with st.sidebar.container():
+        st.markdown('<div class="filter-section">', unsafe_allow_html=True)
+        fuzzy_match = st.checkbox(
+            "Enable fuzzy matching",
+            value=False,
+            help="Allow approximate matches using RapidFuzz"
+        )
+        st.markdown('</div>', unsafe_allow_html=True)
     
     return {
         "search_fields": search_fields,
         "filters": filters,
-        "limit": results_limit
+        "limit": results_limit,
+        "fuzzy_match": fuzzy_match
     }
 
 
@@ -327,7 +338,8 @@ def main():
                     query=query,
                     fields=filter_config["search_fields"],
                     filters=filter_config["filters"],
-                    limit=filter_config["limit"]
+                    limit=filter_config["limit"],
+                    fuzzy=filter_config["fuzzy_match"]
                 )
                 
                 search_time = time.time() - start_time

--- a/backend_requirements.txt
+++ b/backend_requirements.txt
@@ -4,3 +4,4 @@ python-multipart>=0.0.6
 acl-anthology>=0.5.3
 pydantic>=2.4.0
 python-cors>=1.7.0
+rapidfuzz>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit>=1.28.0
 acl-anthology>=0.5.3
 pandas>=1.5.0
 numpy>=1.24.0
+rapidfuzz>=3.0.0

--- a/search_engine.py
+++ b/search_engine.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Any, Set, Optional
 from dataclasses import dataclass
 from acl_anthology import Anthology
 import time
+from rapidfuzz import fuzz
 
 
 @dataclass
@@ -92,7 +93,11 @@ class BooleanSearchEngine:
         
         return text_data
     
-    def _matches_query(self, text_data: Dict[str, str], parsed_query: Dict[str, Any]) -> tuple:
+    def _matches_query(self,
+                        text_data: Dict[str, str],
+                        parsed_query: Dict[str, Any],
+                        fuzzy: bool = False,
+                        fuzzy_threshold: int = 80) -> tuple:
         """Check if paper matches the boolean query"""
         terms = parsed_query["terms"]
         operators = parsed_query["operators"]
@@ -109,9 +114,17 @@ class BooleanSearchEngine:
             term_fields = []
             
             for field, text in text_data.items():
-                if term in text:
-                    term_match = True
-                    term_fields.append(field)
+                if fuzzy:
+                    try:
+                        if fuzz.partial_ratio(term, text) >= fuzzy_threshold:
+                            term_match = True
+                            term_fields.append(field)
+                    except Exception:
+                        pass
+                else:
+                    if term in text:
+                        term_match = True
+                        term_fields.append(field)
             
             match_results.append(term_match)
             if term_match:
@@ -136,11 +149,13 @@ class BooleanSearchEngine:
         
         return result, list(set(match_fields))
     
-    def search(self, 
-               query: str, 
+    def search(self,
+               query: str,
                fields: List[str] = ["title", "abstract", "authors"],
                filters: Optional[Dict[str, Any]] = None,
-               limit: Optional[int] = None) -> List[SearchResult]:
+               limit: Optional[int] = None,
+               fuzzy: bool = False,
+               fuzzy_threshold: int = 80) -> List[SearchResult]:
         """
         Search papers using boolean keywords
         
@@ -169,7 +184,9 @@ class BooleanSearchEngine:
             text_data = self._extract_text_from_paper(paper, fields)
             
             # Check if paper matches query
-            matches, match_fields = self._matches_query(text_data, parsed_query)
+            matches, match_fields = self._matches_query(
+                text_data, parsed_query, fuzzy=fuzzy, fuzzy_threshold=fuzzy_threshold
+            )
             
             if matches:
                 result = SearchResult(

--- a/test_search.py
+++ b/test_search.py
@@ -45,7 +45,7 @@ def test_search_engine():
             print(f"   Year: {result.year}, Venue: {', '.join(result.venue)}")
             print(f"   Matches: {', '.join(result.match_fields)}")
             print()
-    
+
     # Test filters
     print(f"\n{'='*60}")
     print("Testing filters: attention + year 2020-2023")
@@ -61,6 +61,18 @@ def test_search_engine():
     print(f"Found {len(filtered_results)} results")
     for result in filtered_results:
         print(f"- {result.title} ({result.year})")
+
+    # Fuzzy search test
+    print(f"\n{'='*60}")
+    print("Testing fuzzy search: 'transfomer'")
+    print('='*60)
+    fuzzy_results = engine.search(
+        query="transfomer",
+        fields=["title"],
+        limit=5,
+        fuzzy=True
+    )
+    print(f"Found {len(fuzzy_results)} results with fuzzy matching")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support optional fuzzy string matching in search engine using RapidFuzz
- expose fuzzy toggle in Streamlit sidebar and FastAPI API
- document fuzzy search and add RapidFuzz dependency

## Testing
- `pip install -r requirements.txt`
- `pip install -r backend_requirements.txt` *(fails: No matching distribution found for python-cors>=1.7.0)*
- `python test_search.py`


------
https://chatgpt.com/codex/tasks/task_b_68c44fbc77e0832ca5a94d29854508f0